### PR TITLE
Move folder items to minimal model

### DIFF
--- a/src/Projects/MinimalProjectModel.cs
+++ b/src/Projects/MinimalProjectModel.cs
@@ -155,5 +155,10 @@ namespace Vasont.Inspire.Models.Projects
         /// Gets or sets a list of <see cref="ProjectParticipantModel"/> objects.
         /// </summary>
         public List<ProjectParticipantModel> Participants { get; set; } = new List<ProjectParticipantModel>();
+
+        /// <summary>
+        /// Gets or sets a list of <see cref="ProjectFolderItemModel"/> objects.
+        /// </summary>
+        public List<ProjectFolderItemModel> FolderItems { get; set; } = new List<ProjectFolderItemModel>();
     }
 }

--- a/src/Projects/ProjectModel.cs
+++ b/src/Projects/ProjectModel.cs
@@ -18,11 +18,6 @@ namespace Vasont.Inspire.Models.Projects
         public List<ProjectDiscussionModel> Discussions { get; set; } = new List<ProjectDiscussionModel>();
 
         /// <summary>
-        /// Gets or sets a list of <see cref="ProjectFolderItemModel"/> objects.
-        /// </summary>
-        public List<ProjectFolderItemModel> FolderItems { get; set; } = new List<ProjectFolderItemModel>();
-
-        /// <summary>
         /// Gets or sets a list of <see cref="ProjectAssignmentModel"/> objects.
         /// </summary>
         public List<ProjectAssignmentModel> Assignments { get; set; } = new List<ProjectAssignmentModel>();

--- a/src/Vasont.Inspire.Models.csproj
+++ b/src/Vasont.Inspire.Models.csproj
@@ -20,15 +20,15 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>CCMS</PackageTags>
     <PackageReleaseNotes>Added SubmissionAttributeModel</PackageReleaseNotes>
-    <Version>1.2.94</Version>
+    <Version>1.2.95</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <Copyright>Copyright (c) GlobalLink Vasont. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <PropertyGroup>
     <BuildDocFx Condition="$(TargetFramework) != 'netstandard2.1' OR '$(Configuration)' != 'Release'">false</BuildDocFx>
-    <AssemblyVersion>1.2.94.0</AssemblyVersion>
-    <FileVersion>1.2.94.0</FileVersion>
+    <AssemblyVersion>1.2.95.0</AssemblyVersion>
+    <FileVersion>1.2.95.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Assignment update dialog requires folder items, hence moving the folder items attribute to minimal model.

The minimal model is only used by GetProjects API which is not actively used in project, only the PUT and DELETE counterparts are used but this shouldn't affect those APIs.