### PR TITLE
Obsolete model and update ValidationSchemaModel

### DIFF
--- a/src/Configuration/ValidationSchemaModel.cs
+++ b/src/Configuration/ValidationSchemaModel.cs
@@ -35,7 +35,7 @@ namespace Vasont.Inspire.Models.Configuration
         /// <summary>
         /// Gets or sets the validation schema unique identity.
         /// </summary>
-        public long UniqueId { get; set; }
+        public Guid UniqueId { get; set; }
 
         /// <summary>
         /// Gets or sets the name valid value.

--- a/src/Plugins/PluginParameterModel.cs
+++ b/src/Plugins/PluginParameterModel.cs
@@ -5,9 +5,13 @@
 //-------------------------------------------------------------
 namespace Vasont.Inspire.Models.Plugins
 {
+    using System;
+
+    /// TODO: Remove model.
     /// <summary>
     /// This class represents a plugin parameter within the application.
     /// </summary>
+    [Obsolete("No longer used, in favor of DTOs in the projects.")]
     public class PluginParameterModel
     {
         /// <summary>

--- a/src/Vasont.Inspire.Models.csproj
+++ b/src/Vasont.Inspire.Models.csproj
@@ -20,15 +20,15 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>CCMS</PackageTags>
     <PackageReleaseNotes>Added SubmissionAttributeModel</PackageReleaseNotes>
-    <Version>1.3.51</Version>
+    <Version>1.3.52</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <Copyright>Copyright (c) GlobalLink Vasont. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <PropertyGroup>
     <BuildDocFx Condition="$(TargetFramework) != 'netstandard2.1' OR '$(Configuration)' != 'Release'">false</BuildDocFx>
-    <AssemblyVersion>1.3.51.0</AssemblyVersion>
-    <FileVersion>1.3.51.0</FileVersion>
+    <AssemblyVersion>1.3.52.0</AssemblyVersion>
+    <FileVersion>1.3.52.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
PluginParameterModel is no longer referenced/used.

Update ValidationSchemaModel to match the entity. The model uses a `long` for UniqueId, but the entity uses `Guid`