### PR TITLE
Refactored ProjectAssignmentBrowseQueryModel to AdvancedSearchBaseModel

### DIFF
--- a/src/Search/AdvancedSearchBaseModel.cs
+++ b/src/Search/AdvancedSearchBaseModel.cs
@@ -1,19 +1,19 @@
 ﻿//---------------------------------------------------------------------------
-// <copyright file="ProjectAssignmentBrowseQueryModel.cs" company="GlobalLink Vasont">
+// <copyright file="AdvancedSearchBaseModel.cs" company="GlobalLink Vasont">
 // Copyright (c) GlobalLink Vasont. All rights reserved.
 // </copyright>
 //---------------------------------------------------------------------------
-namespace Vasont.Inspire.Models.Projects
+
+namespace Vasont.Inspire.Models.Search
 {
     using System;
     using System.Collections.Generic;
     using Vasont.Inspire.Core.Extensions;
-    using Vasont.Inspire.Models.Search;
 
     /// <summary>
-    /// This class contains parameters passed to the query for retrieving project assignments.
+    /// This class contains parameters passed for advanced search.
     /// </summary>
-    public class ProjectAssignmentBrowseQueryModel
+    public class AdvancedSearchBaseModel
     {
         /// <summary>
         ///  Gets or sets the name of the column to sort by.

--- a/src/Vasont.Inspire.Models.csproj
+++ b/src/Vasont.Inspire.Models.csproj
@@ -20,15 +20,15 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>CCMS</PackageTags>
     <PackageReleaseNotes>Added SubmissionAttributeModel</PackageReleaseNotes>
-    <Version>1.3.59</Version>
+    <Version>1.3.60</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <Copyright>Copyright (c) GlobalLink Vasont. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <PropertyGroup>
     <BuildDocFx Condition="$(TargetFramework) != 'netstandard2.1' OR '$(Configuration)' != 'Release'">false</BuildDocFx>
-    <AssemblyVersion>1.3.59.0</AssemblyVersion>
-    <FileVersion>1.3.59.0</FileVersion>
+    <AssemblyVersion>1.3.60.0</AssemblyVersion>
+    <FileVersion>1.3.60.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This model was used in Project Assignments, but a similar need was there for Workflows as well. Since this model doesn't carry anything specific to project assignments this could be refactored to be a more generic model instead.