### PR TITLE
Save As Component - option to generate all new IDs (Sprint Goal)

### DIFF
--- a/src/Components/SaveAsComponentModel.cs
+++ b/src/Components/SaveAsComponentModel.cs
@@ -67,7 +67,7 @@ namespace Vasont.Inspire.Models.Components
         public bool IsBranch { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the process generate new ids for a saveAs.
+        /// Gets or sets a value indicating whether the process generate new ids for a saveAs function.
         /// </summary>
         public bool GenerateNewIds { get; set; } = false;
     }


### PR DESCRIPTION
For the previous commit I compiled the Model project with other .net framework version   <TargetFrameworks>netstandard5.0</TargetFrameworks>, I have error to update Inspire with that for that reason,
I have fixed the framework version issue and I made a small change on the comment text just to rebuild de DLLs again 