### PR TITLE
Fix Vulnerabilities and deprecations

### DIFF
--- a/src/Common/TenantDetailModel.cs
+++ b/src/Common/TenantDetailModel.cs
@@ -7,7 +7,6 @@
 namespace Vasont.Inspire.Models.Common
 {
     using System;
-    using Vasont.IdentityServer.Backchannel.Models;
 
     /// <summary>
     /// This class represents the basic tenant information needed for the web application.
@@ -28,7 +27,7 @@ namespace Vasont.Inspire.Models.Common
         /// <summary>
         /// Gets or sets the tenant account type.
         /// </summary>
-        public ApplicationSubscriptionLevel SubscriptionLevel { get; set; }
+        //public ApplicationSubscriptionLevel SubscriptionLevel { get; set; }
 
         /// <summary>
         /// Gets or sets the support information about the Tenant.

--- a/src/Vasont.Inspire.Models.csproj
+++ b/src/Vasont.Inspire.Models.csproj
@@ -19,16 +19,16 @@
     <RepositoryUrl>https://github.com/vasont-systems/Vasont.Inspire.Models</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>CCMS</PackageTags>
-    <PackageReleaseNotes>Added SubmissionAttributeModel</PackageReleaseNotes>
-    <Version>1.4.7</Version>
+    <PackageReleaseNotes>Fix Package Vulnerabilities and Deprecations.</PackageReleaseNotes>
+    <Version>1.4.8</Version>
     <NeutralLanguage>en</NeutralLanguage>
-    <Copyright>Copyright (c) GlobalLink Vasont. All rights reserved.</Copyright>
+	<Copyright>Copyright (c) 2025, GlobalLink Vasont. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <PropertyGroup>
     <BuildDocFx Condition="$(TargetFramework) != 'netstandard2.1' OR '$(Configuration)' != 'Release'">false</BuildDocFx>
-    <AssemblyVersion>1.4.7.0</AssemblyVersion>
-    <FileVersion>1.4.7.0</FileVersion>
+    <AssemblyVersion>1.4.8.0</AssemblyVersion>
+    <FileVersion>1.4.8.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -45,18 +45,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="docfx.console" Version="2.57.2">
+    <PackageReference Include="docfx.console" Version="2.59.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Vasont.IdentityServer.Backchannel" Version="1.2.0" />
-    <PackageReference Include="Vasont.Inspire.Core" Version="1.0.33" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
+    <PackageReference Include="Vasont.Inspire.Core" Version="1.0.34" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/docfx.json
+++ b/src/docfx.json
@@ -71,7 +71,7 @@
     },
     "globalMetadata": {
       "_appTitle": "GlobalLink Vasont Inspire Models",
-      "_appFooter": "Copyright 2020 Transperfect Inc.",
+      "_appFooter": "Copyright 2025 GlobalLink Vasont.",
       "_appLogoPath": "images/gl_vasont_logo.png",
       "_appFaviconPath": "images/favicon.ico",
       "_gitContribute": {


### PR DESCRIPTION
Removed Backchannel dependency and updated nuget packages

I checked and the TenantDetailModel isn't used in Inspire anywhere.