### PR TITLE
Fix publish workflow: switch to ubuntu-latest and update action versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,12 +6,12 @@ on:
 jobs:
   publish:
     name: build, pack & publish
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup dotnet core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
            dotnet-version: '8.0.x'
 


### PR DESCRIPTION
the github publish action was still failing after the recent update to net 8. These are the recommended fixes.

- Change runner from windows-latest to ubuntu-latest to fix Docker action compatibility
- Update actions/checkout from v2 to v4
- Update actions/setup-dotnet from v1 to v4